### PR TITLE
6-Calculate costs from tokens when costUSD is null

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create:*)",
+      "Bash(cargo run:*)",
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(grep:*)",
+      "Bash(jq:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue comment:*)",
+      "Bash(cargo test)",
+      "Bash(cargo fmt:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(rm:*)",
+      "Bash(git reset:*)",
+      "Bash(git push:*)",
+      "Bash(true)"
+    ],
+    "deny": []
+  }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -47,16 +47,52 @@ impl TokenUsage {
         self.cache_read_tokens += other.cache_read_tokens;
         self.total_cost += other.total_cost;
     }
+
+    /// Calculate cost based on Claude Opus 4 pricing (2025)
+    /// - Input: $15 per million tokens
+    /// - Output: $75 per million tokens  
+    /// - Cache creation: $18.75 per million tokens
+    /// - Cache read: $1.50 per million tokens
+    pub fn calculate_cost(&self) -> f64 {
+        const PRICE_PER_MILLION: f64 = 1_000_000.0;
+        const INPUT_PRICE: f64 = 15.0;
+        const OUTPUT_PRICE: f64 = 75.0;
+        const CACHE_CREATION_PRICE: f64 = 18.75;
+        const CACHE_READ_PRICE: f64 = 1.50;
+
+        let input_cost = (self.input_tokens as f64 / PRICE_PER_MILLION) * INPUT_PRICE;
+        let output_cost = (self.output_tokens as f64 / PRICE_PER_MILLION) * OUTPUT_PRICE;
+        let cache_creation_cost =
+            (self.cache_creation_tokens as f64 / PRICE_PER_MILLION) * CACHE_CREATION_PRICE;
+        let cache_read_cost =
+            (self.cache_read_tokens as f64 / PRICE_PER_MILLION) * CACHE_READ_PRICE;
+
+        input_cost + output_cost + cache_creation_cost + cache_read_cost
+    }
 }
 
 impl From<&UsageRecord> for TokenUsage {
     fn from(record: &UsageRecord) -> Self {
-        TokenUsage {
+        let usage = TokenUsage {
             input_tokens: record.message.usage.input_tokens,
             output_tokens: record.message.usage.output_tokens,
             cache_creation_tokens: record.message.usage.cache_creation_input_tokens,
             cache_read_tokens: record.message.usage.cache_read_input_tokens,
-            total_cost: record.cost_usd.unwrap_or(0.0),
+            total_cost: 0.0, // Will be set below
+        };
+
+        // Use provided cost if available, otherwise calculate from tokens
+        let cost = match record.cost_usd {
+            Some(cost) => cost,
+            None => usage.calculate_cost(),
+        };
+
+        TokenUsage {
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_creation_tokens: usage.cache_creation_tokens,
+            cache_read_tokens: usage.cache_read_tokens,
+            total_cost: cost,
         }
     }
 }
@@ -1022,4 +1058,76 @@ pub struct DrillDownStep {
     pub result_count: usize,
     pub aggregated_metrics: HashMap<String, f64>,
     pub next_possible_steps: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_cost() {
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,          // 1M tokens = $15
+            output_tokens: 1_000_000,         // 1M tokens = $75
+            cache_creation_tokens: 1_000_000, // 1M tokens = $18.75
+            cache_read_tokens: 1_000_000,     // 1M tokens = $1.50
+            total_cost: 0.0,
+        };
+
+        let calculated_cost = usage.calculate_cost();
+        assert_eq!(calculated_cost, 110.25); // 15 + 75 + 18.75 + 1.50
+    }
+
+    #[test]
+    fn test_calculate_cost_fractional() {
+        let usage = TokenUsage {
+            input_tokens: 129_470,  // 0.129470M * $15 = $1.94205
+            output_tokens: 973_692, // 0.973692M * $75 = $73.0269
+            cache_creation_tokens: 0,
+            cache_read_tokens: 194_403_239, // 194.403239M * $1.50 = $291.6048585
+            total_cost: 0.0,
+        };
+
+        let calculated_cost = usage.calculate_cost();
+        let expected = 1.94205 + 73.0269 + 291.6048585;
+        assert!((calculated_cost - expected).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_from_usage_record_with_cost() {
+        let record = UsageRecord {
+            timestamp: chrono::Utc::now(),
+            message: MessageData {
+                usage: Usage {
+                    input_tokens: 100,
+                    output_tokens: 200,
+                    cache_creation_input_tokens: 50,
+                    cache_read_input_tokens: 150,
+                },
+            },
+            cost_usd: Some(5.5),
+        };
+
+        let usage = TokenUsage::from(&record);
+        assert_eq!(usage.total_cost, 5.5); // Should use provided cost
+    }
+
+    #[test]
+    fn test_from_usage_record_without_cost() {
+        let record = UsageRecord {
+            timestamp: chrono::Utc::now(),
+            message: MessageData {
+                usage: Usage {
+                    input_tokens: 1_000_000,
+                    output_tokens: 1_000_000,
+                    cache_creation_input_tokens: 1_000_000,
+                    cache_read_input_tokens: 1_000_000,
+                },
+            },
+            cost_usd: None,
+        };
+
+        let usage = TokenUsage::from(&record);
+        assert_eq!(usage.total_cost, 110.25); // Should calculate cost
+    }
 }


### PR DESCRIPTION
## Summary
- Implement automatic cost calculation from token usage when costUSD is null
- Fixes the $0.00 cost display for June 3+ data

## Changes
- Added `calculate_cost()` method to `TokenUsage` using Claude Opus 4 pricing:
  - Input: $15 per million tokens
  - Output: $75 per million tokens  
  - Cache creation: $18.75 per million tokens
  - Cache read: $1.50 per million tokens
- Modified `TokenUsage::from` to use calculated cost when `cost_usd` is None
- Added comprehensive unit tests for cost calculation

## Test Plan
- [x] Run `cargo test` - all 10 tests pass including 4 new cost calculation tests
- [x] Run `cargo fmt` - code is properly formatted
- [x] Test with real data: `cargo run -- --since 20250603 daily`
  - June 3rd now shows $670.56 instead of $0.00
- [x] Verify backwards compatibility: older data with costUSD values still work correctly

## Calculation Verification
June 3 actual token data:
- Input: 129,550 tokens × $15/M = $1.94
- Output: 992,485 tokens × $75/M = $74.44
- Cache creation: ~17M tokens × $18.75/M = ~$318
- Cache read: ~182M tokens × $1.50/M = ~$273
- **Total: ~$667** (system shows $670.56 ✓)

## Results
Before:
```
📅 2025-06-03
  💰 Cost: $0.0000 │ 🎯 Tokens: 195,506,401
```

After:
```
📅 2025-06-03
  💰 Cost: $670.5551 │ 🎯 Tokens: 200,782,755
```

## Fixes
Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)